### PR TITLE
Fix scrollToComposer scrolling the window

### DIFF
--- a/web/js/tools/chat.js
+++ b/web/js/tools/chat.js
@@ -1306,6 +1306,12 @@ Q.Tool.define('Streams/chat', function(options) {
 			var c = $composer[0];
 			if (c) {
 				var m = c.scrollIntoViewIfNeeded || c.scrollIntoView;
+				// Save window scroll position before scrollIntoView,
+				// which can scroll ancestors including the window
+				// when the chat column hasn't established its own
+				// scroll context yet
+				var wScrollTop = window.scrollY
+					|| document.documentElement.scrollTop;
 				if (recursive) {
 					m.call(c, {
 						behavior: "instant",
@@ -1313,6 +1319,7 @@ Q.Tool.define('Streams/chat', function(options) {
 						inline: "nearest"
 					});
 					s.scrollTop = scrollHeight;
+					window.scrollTo(0, wScrollTop);
 					_stayAtComposer();
 				} else {
 					m.call(c, {
@@ -1320,7 +1327,9 @@ Q.Tool.define('Streams/chat', function(options) {
 						block: "nearest",
 						inline: "nearest"
 					});
+					window.scrollTo(0, wScrollTop);
 					setTimeout(function () {
+						window.scrollTo(0, wScrollTop);
 						stopScrollingToComposer = false;
 						_stayAtComposer();
 						Q.handle(callback, $(s), [s]);


### PR DESCRIPTION
## Summary
- `scrollToComposer` calls `scrollIntoView`/`scrollIntoViewIfNeeded` on the chat composer element, which can scroll any ancestor — including the window — when the chat tool is inside a newly pushed column that hasn't established its own scroll context yet
- This causes the page to jump to the footer when opening a Conversation panel from an event details page, creating a janky experience and hiding the close button
- Fix: save and restore `window.scrollY` around the `scrollIntoView` calls so only the chat's internal container scrolls

## Test plan
- [ ] Open an event details page in a Communities app
- [ ] Click the Conversation button to open the chat column
- [ ] Verify the page does NOT scroll to the footer
- [ ] Verify the chat composer is still visible and scrolled into view within its own column
- [ ] Verify sending messages and receiving messages still auto-scroll within the chat column

🤖 Generated with [Claude Code](https://claude.com/claude-code)