### PR TITLE
fix(Streams): keep retained stream instances in sync after Streams/changed

### DIFF
--- a/web/js/Streams.js
+++ b/web/js/Streams.js
@@ -537,6 +537,24 @@ var priv = {
             }
         );
     },
+    syncStreamInstances: function priv_syncStreamInstances(canonical) {
+        if (!canonical || !canonical.fields) {
+            return;
+        }
+        var publisherId = canonical.fields.publisherId;
+        var streamName = canonical.fields.name;
+        Q.Streams.get.cache.each([publisherId, streamName], function (k, cached) {
+            var subject = cached && cached.subject;
+            if (!subject || subject === canonical) {
+                return;
+            }
+            Q.extend(subject.fields, canonical.fields);
+            priv.prepareStream(subject);
+            if (canonical.messageTotals) {
+                subject.messageTotals = Q.extend({}, canonical.messageTotals);
+            }
+        });
+    },
     updateAvatarCache: function priv_updateAvatarCache(stream) {
         var avatarStreamNames = {
             'Streams/user/firstName': true,
@@ -2731,7 +2749,23 @@ Sp.retain = function _Stream_prototype_retain (key, options) {
 	var ps = Streams.key(publisherId, streamName);
 	key = Q.calculateKey(key);
 	var wasRetained = !!priv._retainedStreams[ps];
-	var stream = priv._retainedStreams[ps] = this;
+	var canonical = priv._retainedStreams[ps];
+	if (!canonical) {
+		canonical = this;
+	} else if (canonical !== this) {
+		var incCount = parseInt(this.fields.messageCount) || 0;
+		var canCount = parseInt(canonical.fields.messageCount) || 0;
+		if (incCount >= canCount) {
+			Q.extend(canonical.fields, this.fields);
+			priv.prepareStream(canonical);
+		}
+		Q.extend(this.fields, canonical.fields);
+		priv.prepareStream(this);
+		if (canonical.messageTotals) {
+			this.messageTotals = Q.extend({}, canonical.messageTotals);
+		}
+	}
+	var stream = priv._retainedStreams[ps] = canonical;
 	var nodeUrl = Q.nodeUrl({
 		publisherId: publisherId,
 		streamName: streamName
@@ -5099,12 +5133,21 @@ Q.onInit.add(function _Streams_onInit() {
 			}
 
 			function _update(publisherId, streamName, fields, onlyChangedFields) {
+				var ps = Streams.key(publisherId, streamName);
+				var retained = priv._retainedStreams[ps];
+				var cached = Q.Streams.get.cache.get([publisherId, streamName]);
+				var stream = retained || (cached && cached.subject);
+				if (stream) {
+					Stream.update(stream, fields, onlyChangedFields);
+					return;
+				}
 				Q.Streams.get(publisherId, streamName, function (err) {
 					var fem = Q.firstErrorMessage(err);
 					if (fem) {
 						throw new Q.Exception("Streams.update: " + fem);
 					}
-					Stream.update(this, fields, onlyChangedFields);
+					stream = priv._retainedStreams[ps] || this;
+					Stream.update(stream, fields, onlyChangedFields);
 				});
 			}
 		}

--- a/web/js/methods/Streams/Stream/update.js
+++ b/web/js/methods/Streams/Stream/update.js
@@ -110,6 +110,7 @@ Q.exports(function(priv){
         // Now time to replace the fields in the stream with the incoming fields
         Q.extend(stream.fields, fields);
         priv.prepareStream(stream);
+        priv.syncStreamInstances(stream);
         priv.updateMessageTotalsCache(publisherId, streamName, stream.messageTotals);
         priv.updateStreamCache(stream);
         priv.updateAvatarCache(stream);


### PR DESCRIPTION
When a stream was retained by multiple tools, socket-driven Streams/changed updates could apply to a different client-side object than the one tools still held. This showed up when one preview tool was removed while another remained: the surviving tool's onMessage handler still ran, but its stream reference was stale.
Root cause:
- Socket message handling called Stream.update() on the Streams.get cache subject, while tools retained and referenced a separate object via stream.retain(tool).
- stream.retain() replaced the canonical retained instance with whichever object called retain last, allowing divergent copies after related-list refreshes.
- Stream.refresh() already updated priv._retainedStreams, but the socket _update() path did not follow the same rules. Changes:
- Add priv.syncStreamInstances() and call it from Stream.update() so all cached stream objects for the same publisherId/streamName receive the updated fields and parsed attributes after every update.
- Update stream.retain() to keep a single canonical retained instance: merge newer instances in when they have a higher messageCount, then sync the incoming object back from canonical.
- Update socket _update() to apply changes synchronously to the retained stream (or cache subject) before onMessage handlers run, matching Stream.refresh() behavior.