### PR TITLE
Purpose of checkMessageCache in Message.latestOrdinal

### DIFF
--- a/web/js/Streams.js
+++ b/web/js/Streams.js
@@ -3666,24 +3666,23 @@ Mp.seen = function _Message_seen (messageTotal) {
  * @return {Integer}
  */
 Message.latestOrdinal = function _Message_latestOrdinal (publisherId, streamName, checkMessageCache) {
-	var found = false;
 	var latest = 0;
 	if (checkMessageCache) {
 		Message.get.cache.each([publisherId, streamName], function (k, v) {
 			if (!v.params[0] && v.subject.ordinal > 0) {
 				latest = Math.max(latest, v.subject.ordinal);
-				found = true;
 			}
 		});
+
+		return parseInt(latest) || 0;
 	}
 	Streams.get.cache.each([publisherId, streamName], function (k, v) {
 		if (!v.params[0] && v.subject.fields.messageCount > 0) {
-			latest = v.subject.fields.messageCount;
-			found = true;
+			latest = Math.max(latest, v.subject.fields.messageCount);
 			return false;
 		}
 	});
-	return found ? parseInt(latest) : 0;
+	return parseInt(latest) || 0;
 };
 
 /**


### PR DESCRIPTION
When Message.latestOrdinal is called with checkMessageCache=true, its sole purpose is to verify whether a message already exists in the message cache—regardless of the current stream.messageCount value. This is necessary because stream.messageCount may not always update in sync with actual message arrival.

Why stream.messageCount alone is insufficient for Message.wait: Even if stream.messageCount is updated before the corresponding message data arrives on the client, it is useless for Message.wait—the real message hasn't been received yet and therefore cannot be processed. That's why, when checkMessageCache=true, the method should simply check the messages cache and return whatever value is found there, without considering stream.messageCount.

Handling discrepancies:
If the messages cache shows that latest message.ordinal is greater than stream.messageCount, it means the message has already arrived on the client, but the stream's messageCount hasn't been updated yet. In this case, the client should update stream.messageCount to reflect the new value.

Where this happens:
This exact behavior occurs when Message.latestOrdinal is called with checkMessageCache=false inside Q.Socket.onEvent('Streams/post').